### PR TITLE
feat: improve test setup

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -55,7 +55,6 @@ jobs:
 
       - name: "Run plugin tests"
         run: |
-          ls -l "${FTW_LOGFILE}"
           ./ftw check -d tests/regression
           ./ftw run -d tests/regression
         env:
@@ -63,4 +62,4 @@ jobs:
       
       - name: "Tear down tests"
         run: |
-          docker-compose -f tests/integration/docker-compose.yml down
+          docker-compose -f tests/integration/docker-compose.yml down -t 0

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -48,4 +48,4 @@ jobs:
         run: |
           pip install --upgrade setuptools
           pip install secrules-parsing
-          secrules-parser -c --output-type github -f plugins/*.conf
+          secrules-parser -c -v --output-type github -f plugins/*.conf

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - ../../crs/rules:/opt/owasp-crs/rules:ro
       - ../../plugins:/opt/owasp-crs/plugins:ro
       - ../logs/apache:/var/log:rw
+      - ../../crs-setup.conf.example:/etc/modsecurity.d/owasp-crs/crs-setup.conf.example
     networks:
       - crs-plugins-net
   
@@ -56,11 +57,12 @@ services:
       - ../../crs/rules:/opt/owasp-crs/rules:ro
       - ../../plugins:/opt/owasp-crs/plugins:ro
       - ../logs/nginx:/var/log/nginx:rw
+      - ../../crs-setup.conf.example:/etc/modsecurity.d/owasp-crs/crs-setup.conf.example
     networks:
       - crs-plugins-net
 
   backend:
-    image: eexit/mirror-http-server #docker.io/kennethreitz/httpbin
+    image: eexit/mirror-http-server
     networks:
       - crs-plugins-net
   


### PR DESCRIPTION
- Override crs-setup.conf in compose file, like we do for core, to ensure that we're using the correct configuration. Previously, the rules would be picked up (CRS v4) but the configuration wouldn't be correct (CRS v3.3.5), which had the effect, that the paranoia level setting was not applied and that test were only being run against paranoia level 1.
- Show line number for syntax failures.
- Force compose shutdown on GH.