### PR TITLE
fix: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -3,6 +3,9 @@ name: Integration/Regression
 
 on:                   # yamllint disable-line rule:truthy
   workflow_call:
+
+permissions:
+  contents: read
     inputs:
       crs-config:
         required: false

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,6 +4,8 @@ name: Lint Plugin
 on:                  # yamllint disable-line rule:truthy
   workflow_call:
 
+permissions:
+  contents: read
 
 jobs:
   check-syntax:
@@ -36,7 +38,7 @@ jobs:
                 min-spaces-from-content: 1
 
       - name: Linelint
-        uses: fernandrone/linelint@master
+        uses: fernandrone/linelint@7907a5dca0c28ea7dd05c6d8d8cacded713aca11 # master
         id: linelint
 
       - name: Set up Python 3


### PR DESCRIPTION
## what

- pin `fernandrone/linelint` to commit SHA instead of mutable `master` branch
- add explicit `permissions: contents: read` to reusable lint and integration workflows

## why

- `fernandrone/linelint@master` tracks a mutable branch — a compromised upstream could inject arbitrary code that runs in every plugin repo that uses this reusable workflow (~20 repos)
- this repo is the upstream reusable workflow for most CRS plugins, so hardening it has org-wide impact
- explicit permissions follow the principle of least privilege

## refs

- [GitHub docs: security hardening for GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions)