### PR TITLE
ci: test plugins against both CRS main and current LTS

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -32,7 +32,7 @@ jobs:
         run: |
           set -euo pipefail
           lts=$(gh api --paginate repos/coreruleset/coreruleset/releases \
-            --jq '[.[] | select(.prerelease == false) | select(.name | test("\\(LTS\\)"))][0].tag_name')
+            --jq '[.[] | select(.prerelease == false) | select((.name // "") | test("\\(LTS\\)"))][0].tag_name')
           if [ -z "$lts" ] || [ "$lts" = "null" ]; then
             echo "::error::Could not resolve current CRS LTS release tag" >&2
             exit 1

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -20,22 +20,48 @@ env:
   GO_FTW_VERSION: "v2.1.0"
 
 jobs:
+  resolve-crs-refs:
+    runs-on: ubuntu-latest
+    outputs:
+      refs: ${{ steps.resolve.outputs.refs }}
+    steps:
+      - name: "Resolve current LTS tag"
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          lts=$(gh api --paginate repos/coreruleset/coreruleset/releases \
+            --jq '[.[] | select(.prerelease == false) | select(.name | test("\\(LTS\\)"))][0].tag_name')
+          if [ -z "$lts" ] || [ "$lts" = "null" ]; then
+            echo "::error::Could not resolve current CRS LTS release tag" >&2
+            exit 1
+          fi
+          echo "Resolved LTS tag: $lts"
+          printf 'refs=["main","%s"]\n' "$lts" >> "$GITHUB_OUTPUT"
+
   modsecurity-test:
+    needs: resolve-crs-refs
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
         backend: ${{ fromJSON(inputs.backends) }}
+        crs-ref: ${{ fromJSON(needs.resolve-crs-refs.outputs.refs) }}
 
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-      - name: "Checkout CRS"
+      - name: "Checkout CRS (${{ matrix.crs-ref }})"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: coreruleset/coreruleset
+          ref: ${{ matrix.crs-ref }}
           path: crs
+          persist-credentials: false
 
       - name: "Install dependencies"
         env:
@@ -48,27 +74,28 @@ jobs:
           curl -skL https://raw.githubusercontent.com/coreruleset/crs-plugin-test-action/main/tests/integration/docker-compose.yml \
             -o tests/integration/docker-compose.yml
       
-      - name: "Start ${{ matrix.backend }} "
+      - name: "Start ${{ matrix.backend }}"
         env:
+          BACKEND: ${{ matrix.backend }}
           EXTRA_CONF: ${{ inputs.crs-config }}
         run: |
           # create logs directory
-          mkdir -p tests/logs/${{ matrix.backend }}
-          chmod a+rw tests/logs/${{ matrix.backend }}
+          mkdir -p "tests/logs/${BACKEND}"
+          chmod a+rw "tests/logs/${BACKEND}"
           # use crs-config, if any
           echo "$EXTRA_CONF" > /tmp/crs-additional-setup.conf
           # start container
-          docker compose -f tests/integration/docker-compose.yml up -d ${{ matrix.backend }}
-          docker logs -f ${{ matrix.backend }} &
+          docker compose -f tests/integration/docker-compose.yml up -d "${BACKEND}"
+          docker logs -f "${BACKEND}" &
           # Give some room before next phase
           sleep 2
 
       - name: "Run plugin tests"
+        env:
+          FTW_LOGFILE: 'tests/logs/${{ matrix.backend }}/error.log'
         run: |
           ./ftw check -d tests/regression
           ./ftw run -d tests/regression --show-failures-only
-        env:
-          FTW_LOGFILE: 'tests/logs/${{ matrix.backend }}/error.log'
       
       - name: "Tear down tests"
         run: |


### PR DESCRIPTION
## Summary

- New `resolve-crs-refs` job queries `coreruleset/coreruleset` releases and picks the newest non-prerelease whose name contains `(LTS)` (currently `v4.25.0`). Output is consumed by the existing `modsecurity-test` job as a new `crs-ref` matrix dimension, so each backend now runs against both `main` and the current LTS tag.
- `fail-fast: true` is preserved — first failure stops the matrix.
- Drive-by: fixed `zizmor` template-injection warnings by routing `matrix.backend` through a `BACKEND` env var with quoted shell expansions, and set `persist-credentials: false` on both `actions/checkout` calls.

Motivation: plugin tests currently only exercise CRS `main`. Running the same suite against the active LTS line lets plugin maintainers catch version-specific false positives before shipping.

## Test plan

- [ ] Trigger this workflow from a consuming plugin repo and confirm the matrix expands to 4 combinations (`apache`/`nginx` × `main`/`<lts-tag>`).
- [ ] Confirm the resolved LTS tag appears in the `resolve-crs-refs` job log.
- [ ] Verify checkouts succeed for both refs and `ftw run` executes against each.
- [ ] Re-run `zizmor .github/workflows/integration.yaml` and confirm no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)